### PR TITLE
fix: wrong path for test split images in evaluation branch

### DIFF
--- a/src/datasets/arctic_dataset.py
+++ b/src/datasets/arctic_dataset.py
@@ -385,7 +385,9 @@ class ArcticDataset(Dataset):
         if load_rgb:
             if speedup:
                 imgname = imgname.replace("/images/", "/cropped_images/")
-            imgname = imgname.replace("/arctic_data/", "/data/arctic_data/data/")
+            imgname = imgname.replace(
+                "/arctic_data/", "/data/arctic_data/data/"
+            ).replace("/data/data/", "/data/")
             cv_img, img_status = read_img(imgname, (2800, 2000, 3))
         else:
             norm_img = None


### PR DESCRIPTION
You forgot to add this patch from the `getitem` function to the `getitem_eval` function. Without this, the proposed `python scripts_method/extract_predicts.py --setup p2 --method arctic_sf --load_ckpt logs/28bf3642f/checkpoints/last.ckpt --run_on test --extraction_mode submit_pose` doesn't work on the test set because it will try to use `./data/arctic_data/data/data/cropped_images/...` for the images.

https://github.com/zc-alexfan/arctic/blob/facdf72d5b8ac0aad245f94553a17a0339e912aa/src/datasets/arctic_dataset.py#L119-L121